### PR TITLE
[H2BLB][GISel] Use custom incoming value assigner

### DIFF
--- a/llvm/lib/Target/H2BLB/GISel/H2BLBCallLowering.cpp
+++ b/llvm/lib/Target/H2BLB/GISel/H2BLBCallLowering.cpp
@@ -65,7 +65,7 @@ namespace {
 
 struct H2BLBIncomingValueAssigner : public CallLowering::IncomingValueAssigner {
   H2BLBIncomingValueAssigner(CCAssignFn *AssignFn_, CCAssignFn *AssignFnVarArg_,
-                             const H2BLBSubtarget &Subtarget_, bool IsReturn)
+                             bool IsReturn)
       : IncomingValueAssigner(AssignFn_, AssignFnVarArg_) {}
 
   bool assignArg(unsigned ValNo, EVT OrigVT, MVT ValVT, MVT LocVT,
@@ -341,7 +341,7 @@ bool H2BLBCallLowering::lowerFormalArguments(MachineIRBuilder &MIRBuilder,
 
   CCAssignFn *AssignFn = CC_H2BLB_Common;
 
-  CallLowering::IncomingValueAssigner Assigner(AssignFn, AssignFn);
+  H2BLBIncomingValueAssigner Assigner(AssignFn, AssignFn, /*IsReturn*/ false);
   FormalArgHandler Handler(MIRBuilder, MRI);
   SmallVector<CCValAssign, 16> ArgLocs;
   CCState CCInfo(F.getCallingConv(), F.isVarArg(), MF, ArgLocs, F.getContext());


### PR DESCRIPTION
### Summary

Use H2BLBIncomingValueAssigner instead of the base CallLowering::IncomingValueAssigner when lowering formal arguments.

This is mainly a consistency cleanup. H2BLBIncomingValueAssigner overrides assignArg(), but the previous code instantiated the base assigner directly, so the custom override was never used. The book example also uses H2BLBIncomingValueAssigner at this point.

No functional change is expected, since the override currently delegates to the same AssignFn path.